### PR TITLE
Fix duplicate OnMsg.ModsReloaded clobbering LH_Milk/LH_Eggs perk injection

### DIFF
--- a/Code/upgradeCall.lua
+++ b/Code/upgradeCall.lua
@@ -412,6 +412,7 @@ function OnMsg.ModsReloaded()
 			end
 		end)
 	end
+	build_pivot_tables()
 end
 
 --Input: evo_pivot[unit_id] output: evo unit list
@@ -492,10 +493,6 @@ end
 
 function get_evo_Table()
 	return EE_evo_pivot
-end
-
-function OnMsg.ModsReloaded()
-	build_pivot_tables()
 end
 
 function Get_unit_classes()


### PR DESCRIPTION
## Summary

`Code/upgradeCall.lua` declares `OnMsg.ModsReloaded` twice. In Lua, `function OnMsg.ModsReloaded() ... end` is sugar for `OnMsg.ModsReloaded = function() ... end`, so the second declaration silently overwrites the first — only the second handler ever runs.

- The **first** declaration (was at line 386) starts the `LH_Milk` and `LH_Eggs` perk-injection threads when those mods are present.
- The **second** declaration (was at line 497) calls `build_pivot_tables()`.

Result: with the second handler winning, `build_pivot_tables()` runs but the LH_Milk / LH_Eggs perk injection never fires. Players running Enemies Evolve! alongside LH_Milk or LH_Eggs get no milk/eggs perks added to animals.

## Fix

Merge both handlers into a single `OnMsg.ModsReloaded` so all three actions run on every reload:

1. LH_Milk perk injection (if `LH_Milk` is loaded)
2. LH_Eggs perk injection (if `LH_Eggs` is loaded)
3. `build_pivot_tables()`

The second declaration is removed.