### PR TITLE
Fix base_SKarabei_chain typo in 6 StoryBit prereqs

### DIFF
--- a/items.lua
+++ b/items.lua
@@ -7636,7 +7636,7 @@ PlaceObj('ModItemFolder', {
 		OneTime = false,
 		Prerequisites = {
 			PlaceObj('CheckExpression', {
-				Expression = function (self, obj) return not UnlockedAttackChains["base_SKarabei_chain"] end,
+				Expression = function (self, obj) return not UnlockedAttackChains["base_Skarabei_chain"] end,
 				param_bindings = false,
 			}),
 		},
@@ -7698,7 +7698,7 @@ PlaceObj('ModItemFolder', {
 				param_bindings = false,
 			}),
 			PlaceObj('CheckExpression', {
-				Expression = function (self, obj) return UnlockedAttackChains["base_SKarabei_chain"] and not UnlockedAttackChains["base_Dragonfly_chain"] end,
+				Expression = function (self, obj) return UnlockedAttackChains["base_Skarabei_chain"] and not UnlockedAttackChains["base_Dragonfly_chain"] end,
 				param_bindings = false,
 			}),
 			PlaceObj('CheckTime', {
@@ -7761,7 +7761,7 @@ PlaceObj('ModItemFolder', {
 				param_bindings = false,
 			}),
 			PlaceObj('CheckExpression', {
-				Expression = function (self, obj) return UnlockedAttackChains["base_SKarabei_chain"] and not UnlockedAttackChains["base_Shrieker_chain"] end,
+				Expression = function (self, obj) return UnlockedAttackChains["base_Skarabei_chain"] and not UnlockedAttackChains["base_Shrieker_chain"] end,
 				param_bindings = false,
 			}),
 		},
@@ -7820,7 +7820,7 @@ PlaceObj('ModItemFolder', {
 				param_bindings = false,
 			}),
 			PlaceObj('CheckExpression', {
-				Expression = function (self, obj) return UnlockedAttackChains["base_SKarabei_chain"] and not UnlockedAttackChains["base_Scissorhands_chain"] end,
+				Expression = function (self, obj) return UnlockedAttackChains["base_Skarabei_chain"] and not UnlockedAttackChains["base_Scissorhands_chain"] end,
 				param_bindings = false,
 			}),
 		},
@@ -7876,7 +7876,7 @@ PlaceObj('ModItemFolder', {
 				param_bindings = false,
 			}),
 			PlaceObj('CheckExpression', {
-				Expression = function (self, obj) return UnlockedAttackChains["base_SKarabei_chain"] and not UnlockedAttackChains["base_Juno_chain"] end,
+				Expression = function (self, obj) return UnlockedAttackChains["base_Skarabei_chain"] and not UnlockedAttackChains["base_Juno_chain"] end,
 				param_bindings = false,
 			}),
 		},
@@ -7934,7 +7934,7 @@ PlaceObj('ModItemFolder', {
 				param_bindings = false,
 			}),
 			PlaceObj('CheckExpression', {
-				Expression = function (self, obj) return UnlockedAttackChains["base_SKarabei_chain"] and not UnlockedAttackChains["base_Glutch_chain"] end,
+				Expression = function (self, obj) return UnlockedAttackChains["base_Skarabei_chain"] and not UnlockedAttackChains["base_Glutch_chain"] end,
 				param_bindings = false,
 			}),
 		},


### PR DESCRIPTION
Six "Initial X" attack story bits look up an attack-chain key that's spelled slightly differently than the one actually set at runtime: base_SKarabei_chain (capital K) in the prereqs vs base_Skarabei_chain (lowercase k) everywhere else. Since the capital-K key is never set, the prereqs always evaluate the same way:

- Initial Skarabei keeps firing forever: its prereq is not <missing-key>, which is always true.
- Initial Dragonfly, Shrieker, Scissorhands, Junos, and Manhunting Glutch never fire at all: their prereqs short-circuit on the missing key.

This lines up with the Workshop reports of "attacks stop coming after a few days"; once the Skarabei cycle plays out, nothing else queues up.