### PR TITLE
Fix instance.spawnClass casing so robot wave-upgrades apply

### DIFF
--- a/Code/upgradeCall.lua
+++ b/Code/upgradeCall.lua
@@ -1014,7 +1014,7 @@ function ILU_ActivateAttackDropshipSpawnDefs(robot_spawndef, main_unit, added_un
 	progress_mul = progress_mul or 100
 	local addedClassList = {}
 	local instance = {}
-	instance.spawnClass, addedClassList = check_count_and_upgrade(main_unit, added_units)
+	instance.SpawnClass, addedClassList = check_count_and_upgrade(main_unit, added_units)
 	instance.AdditionalClassList = {}
 	for i = 1, #addedClassList do
 		instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { addedClassList[i]['id'], addedClassList[i]


### PR DESCRIPTION
ILU_ActivateAttackDropshipSpawnDefs set instance.spawnClass (lowercase) before CreateInstance, but the SpawnDef property is SpawnClass. CreateInstance silently drops the unknown key, so robot attack waves spawned their default class instead of the upgraded one from check_count_and_upgrade. Matches the correct instance.SpawnClass usage already at upgradeCall.lua:386 and :407.