### PR TITLE
Seed UnlockedAttackChains on new game to prevent Mixed-attack crash

### DIFF
--- a/Code/upgradeCall.lua
+++ b/Code/upgradeCall.lua
@@ -1206,3 +1206,12 @@ end
 OnMsg.ApplyModOptions = EE_init_and_set_options
 OnMsg.LoadGame = Attack_mem_cleanup
 OnMsg.GameStarted = EE_Instantiate
+-- Seed/migrate UnlockedAttackChains on a fresh new game too. Attack_mem_cleanup
+-- was only wired to LoadGame, which never fires for a brand-new game, so a fresh
+-- game left UnlockedAttackChains empty; a no-Prerequisite AnimalAttack_Mixed could
+-- then reach Attack_instance_fill with no unlocked chain and index a nil chain def.
+-- GameStarted fires for both new and loaded games once Game/Scenario are ready
+-- (unlike NewGame, which races MapVar init, or EE_Instantiate, which also runs at
+-- main-menu ApplyModOptions where Scenario is nil). OnMsg appends, so this runs
+-- alongside EE_Instantiate; the extra run on load is idempotent.
+OnMsg.GameStarted = Attack_mem_cleanup


### PR DESCRIPTION
Attack_mem_cleanup (which seeds/migrates UnlockedAttackChains) was only wired to OnMsg.LoadGame, which never fires for a brand-new game. A fresh game therefore started with UnlockedAttackChains empty.

AnimalAttack_Mixed has no Prerequisites, so when the attack scheduler activates it on a fresh game its FillInstance calls Attack_instance_fill(false, true) with no unlocked chain. The base/second/third chain fallback loops draw from table.keys(UnlockedAttackChains), which is empty, leaving base_c_def nil and crashing at base_c_def:get_units_by_tier(min_tier) (upgradeCall.lua:905).

Wire Attack_mem_cleanup to OnMsg.GameStarted as well. GameStarted fires for both new and loaded games after Game/Scenario/MapVars are ready, unlike NewGame (which races MapVar init) or EE_Instantiate (which also runs at main-menu ApplyModOptions where Scenario is nil). OnMsg appends, so this runs alongside the existing EE_Instantiate handler; the extra run on load is idempotent. A new game now seeds the same base chains a loaded game already does, so there is no balance change.