### PR TITLE
Fix 2-arg MulDivRound in Coalesce_mass_animals EP-coalesce path

### DIFF
--- a/Code/upgradeCall.lua
+++ b/Code/upgradeCall.lua
@@ -378,7 +378,7 @@ function Coalesce_mass_animals()
 				end,units_check,total_EP_scrubbed)
 			end
 			if total_EP_scrubbed > 0 then
-				local percent = MulDivRound(total_EP_scrubbed*100,EventProgress)
+				local percent = MulDivRound(total_EP_scrubbed, 100, EventProgress)
 				Bkob_Log("Coalescing some EP from deleted units into a singel EE attack")
     			local spawn_def = SpawnDefs['Single']
 				local instance = {}


### PR DESCRIPTION
MulDivRound is a 3-arg engine global (v, m, d); the call in the EP-coalesce path passed only 2 args, leaving d nil and erroring. OnMsg.NewDayStarted handlers run under procall so the error was caught, but it aborted Coalesce_mass_animals before the compensating attack spawned: on any day a chain exceeds 500 alive aggressive units, the excess is deleted (lag avoidance) but the coalesced attack that should replace it never fires.

Fixed to the 3-arg form with the same intended math, (total_EP_scrubbed * 100) / EventProgress rounded.