### PR TITLE
Remove unreachable ILU_set_mod_options branch in check_count_and_upgrade

### DIFF
--- a/Code/upgradeCall.lua
+++ b/Code/upgradeCall.lua
@@ -926,8 +926,6 @@ function check_count_and_upgrade(start_animal, additionalClassList, progress_per
 	progress_percent = progress_percent or 100
 	local actual_EP_Bank = DivRound((progress_percent * EventProgress), 100)
 	local max_count = ILU_max
-	if not max_count then ILU_set_mod_options("rtw6tLg") end
-	local max_count = ILU_max
 	local min_average_cost = DivRound(actual_EP_Bank, max_count)
 	local start_ep = g_Classes[start_animal].EventProgressValue --lookupEP(start_animal)
 	local temp_class_list = {


### PR DESCRIPTION
The guard `if not max_count then ILU_set_mod_options("rtw6tLg") end` called a function that does not exist (the real one is EE_set_mod_options), so it would throw attempt-to-call-a-nil-value if ever reached. It never is: max_count = ILU_max, a MapVar that is false outside an active map and is set to its default (150) at NewMap, then reset to false at PostDoneMap. check_count_and_upgrade runs only from attack-assembly paths during live gameplay, where a map exists and ILU_max is always a number, so `not max_count` is never true. Even if reached, EE_set_mod_options early-returns unless CurrentModId matches the active mod, so the call carried no live initialization.

Removed the dead branch and the now-redundant re-read of ILU_max; max_count is not referenced after this point.