### PR TITLE
Build evo/tier pivots once instead of on every lookup

### DIFF
--- a/Code/upgradeCall.lua
+++ b/Code/upgradeCall.lua
@@ -524,14 +524,16 @@ end
 
 
 function EE_get_evo(unit_class)
-	if #EE_evo_pivot == 0 then
+	-- # is 0 on a string-keyed table, so the old `#pivot == 0` was always true and rebuilt every call;
+	-- next() is the real emptiness test, so the pivot now builds once and caches.
+	if next(EE_evo_pivot) == nil then
 		Build_evo_pivot()
 	end
 	return EE_evo_pivot[unit_class]
 end
 
 function EE_get_tier(unit_class)
-	if #EE_tier_pivot == 0 then
+	if next(EE_tier_pivot) == nil then
 		Build_tier_pivot()
 	end
 	return EE_tier_pivot[unit_class]


### PR DESCRIPTION
EE_evo_pivot and EE_tier_pivot are string-keyed, so `#pivot` is always 0 and the `#pivot == 0` guards in EE_get_evo/EE_get_tier were always true; Build_evo_pivot/Build_tier_pivot ran on every lookup, rebuilding the whole pivot from the UnitClassChain presets each time (and one evolution calls these many times via Find_evolution). Use `next(pivot) == nil`, the correct emptiness test for a hash table, so each pivot builds once and caches.